### PR TITLE
Resolve tsx parsing error

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -14,6 +14,7 @@ module.exports = {
           {
             ts: 'never',
             vue: 'always',
+            tsx: 'never',
           },
         ],
       },


### PR DESCRIPTION
I previously submitted a pull request #3 to make the settings apply to tsx as well.
However, I forgot to add the import/extensions setting and that caused a problem.

Changed to prohibit the use of the .tsx extension.