### PR TITLE
Add a rule set for React

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ export function foo() {}
 
 - `@toyokumo/eslint-config`
   - Base rule set. At least use this.
+- `@toyokumo/eslint-config/rules/react.js`
+  - Support of react for `*.jsx`, `*.tsx` files. This ruleset is intended to be used with `@toyokumo/eslint-config/rules/typescript.js`.
 - `@toyokumo/eslint-config/rules/typescript.js`
   - Support of typescript for `*.ts` files.
 - `@toyokumo/eslint-config/rules/vue2.js`

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.9",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-react": "^7.26.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-vue": "^7.7.0"
   },
   "devDependencies": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,23 +1,24 @@
 module.exports = {
-  overrides: [{
-    files: ['*.ts', '*.tsx'],
-    plugins: ['react', "jsx-a11y", "react-hooks"],
-    extends: [
-      "plugin:react/recommended",
-      "plugin:react-hooks/recommended",
-      "plugin:jsx-a11y/recommended",
-      "prettier",
-    ],
-    parserOptions: {
-      ecmaFeatures: {
-        "jsx": true,
-      }
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      plugins: ['react', 'jsx-a11y', 'react-hooks'],
+      extends: [
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
+        'plugin:jsx-a11y/recommended',
+        'prettier',
+      ],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      settings: {
+        react: {
+          version: 'detect',
+        },
+      },
     },
-    settings: {
-      react: {
-        version: 'detect'
-      }
-    }
-  }
-  ]
-}
+  ],
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,0 +1,23 @@
+module.exports = {
+  overrides: [{
+    files: ['*.ts', '*.tsx'],
+    plugins: ['react', "jsx-a11y", "react-hooks"],
+    extends: [
+      "plugin:react/recommended",
+      "plugin:react-hooks/recommended",
+      "plugin:jsx-a11y/recommended",
+      "prettier",
+    ],
+    parserOptions: {
+      ecmaFeatures: {
+        "jsx": true,
+      }
+    },
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    }
+  }
+  ]
+}

--- a/tests/react/bad.jsx
+++ b/tests/react/bad.jsx
@@ -1,0 +1,1 @@
+// TODO: If add a rule that differs from the recommendation, add a test

--- a/tests/react/good.jsx
+++ b/tests/react/good.jsx
@@ -1,0 +1,1 @@
+// TODO: If add a rule that differs from the recommendation, add a test


### PR DESCRIPTION
Added a ruleset for React.
The following plugins have been newly added.
- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)
- [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks)
- [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)


Except for the following settings, I have followed the official recommendations.
```
settings: {
      react: {
        version: 'detect'
      }
    }
```
If this setting is not present, we will get a warning to specify the React version.
