### PR TITLE
turn off the two rules of react

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -19,6 +19,10 @@ module.exports = {
           version: 'detect',
         },
       },
+      rules: {
+        'react/react-in-jsx-scope': 'off',
+        'react/require-default-props': 'off',
+      },
     },
   ],
 };


### PR DESCRIPTION
- `react/react-in-jsx-scope`
This rule is not required in React 17 or later. Also, this rule is set to off in the eslint-config of Next.js.
https://github.com/vercel/next.js/blob/c2e73ead7f6b309d6f568ebbb776145790809b0e/packages/eslint-config-next/index.js#L18
- `react/require-default-props`
This rule is recommended to be used to take advantage of React's [propTypes](https://reactjs.org/docs/typechecking-with-proptypes.html#gatsby-focus-wrapper), even if you are using typescript. However, after some discussion, we decided that typescript is sufficient for this feature, so we turn it off.