### PR TITLE
Enable ESLint Rule: consistent-type-imports

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -19,6 +19,12 @@ module.exports = {
             tsx: 'never',
           },
         ],
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            prefer: 'type-imports',
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
### 具体的に何をしたのか
TypeScriptで型情報をimportする際に，`import type { typeName }`を使うように強制する[ルール](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md)の有効化をしました．

### なぜこの変更方法を選択したのか、なぜこの変更で課題が解決するのか
手元でruleが効いているのを確認しました．

### どうやってこの変更を読めばいいのか
f5254fefd2fda4a3d29b80a575c26306db05a0a6 rules/typescript.jsにルールを追加．

### その他
