### PR TITLE
Add rules related to tailwindcss

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ export function foo() {}
   - Support of vue2 with typescript in script tag for `*.vue` files.
 - `@toyokumo/eslint-config/rules/jest.js`
   - Support of jest.
+- `@toyokumo/eslint-config/rules/tailwindcss.js`
+  - Support of tailwindcss for `*.ts`, `*.tsx` files.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export function foo() {}
 - `@toyokumo/eslint-config/rules/jest.js`
   - Support of jest.
 - `@toyokumo/eslint-config/rules/tailwindcss.js`
-  - Support of tailwindcss for `*.ts`, `*.tsx` files.
+  - Support of tailwindcss for `*.ts`, `*.tsx`, `*.vue` files.
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-tailwindcss": "^3.12.1",
     "eslint-plugin-vue": "^8.4.1"
   },
   "devDependencies": {

--- a/rules/tailwindcss.js
+++ b/rules/tailwindcss.js
@@ -1,9 +1,8 @@
 module.exports = {
   overrides: [
     {
-      files: ['*.ts', '*.tsx'],
+      files: ['*.ts', '*.tsx', '*.vue'],
       plugins: ['tailwindcss'],
-      parser: '@typescript-eslint/parser',
       extends: ['plugin:tailwindcss/recommended'],
     },
   ],

--- a/rules/tailwindcss.js
+++ b/rules/tailwindcss.js
@@ -1,0 +1,10 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      plugins: ['tailwindcss'],
+      parser: '@typescript-eslint/parser',
+      extends: ['plugin:tailwindcss/recommended'],
+    },
+  ],
+};

--- a/tests/tailwind/bad.tsx
+++ b/tests/tailwind/bad.tsx
@@ -1,0 +1,1 @@
+// TODO: If add a rule that differs from the recommendation, add a test

--- a/tests/tailwind/good.tsx
+++ b/tests/tailwind/good.tsx
@@ -1,0 +1,1 @@
+// TODO: If add a rule that differs from the recommendation, add a test


### PR DESCRIPTION
Added eslint rules regarding tailwind.
They are based on this eslint-plugin.
https://www.npmjs.com/package/eslint-plugin-tailwindcss
For now, we are using the recommended rules as they are, because we are not particularly particular about them.
