### PR TITLE
Add prettier config file as devDependencies importable

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -19,6 +19,8 @@ module.exports = {
           '**/webpack.config.js',
           '**/webpack.config.*.js',
           '**/eslint.config.{js,ts}',
+          '**/.prettierrc.{js,cjs,mjs}',
+          '**/prettier.config.{js,cjs,mjs}',
         ],
       },
     ],


### PR DESCRIPTION
Add prettier config file to "import/no-extraneous-dependencies" rule.

prettier valid config files are listed in https://prettier.io/docs/en/configuration.html